### PR TITLE
bugfix: Demo minigame runs more than once

### DIFF
--- a/demo_minigame/__init__.py
+++ b/demo_minigame/__init__.py
@@ -53,6 +53,7 @@ class DemoMinigame:
         """
         # in this case, use a threading.Event so we can efficiently wait for
         # something that happens in a callback (quit clicked)
+        self.return_start.clear()
         self.return_start.wait()
 
     def score_up(self, _):


### PR DESCRIPTION
In short, the system used to wait for the app to complete to return from `start` wasn't reset correctly in subsequent runs of the demo, so the demo minigame launched and closed instantly. 